### PR TITLE
Disabled validation during download

### DIFF
--- a/utils/storage-utils.js
+++ b/utils/storage-utils.js
@@ -16,7 +16,8 @@ function downloadFile(file, fileName) {
     return new Promise((resolve, reject) => {
         let tempDestination = '/tmp/' + fileName;
         file.download({
-            destination: tempDestination
+            destination: tempDestination,
+            validation: false
         }).then((error) => {
             console.log('Download is done ' + error);
             if (error.length > 0) {


### PR DESCRIPTION
Function was randomly failing since validation was returning incorrect even though the file was correct (in fact, all worked flawlessly after disabling validation).
Not sure why it was failing but I highly doubt that a file transfer from GCS to GCF can corrupt the file without aborting the connection so I don't think we really need validation here.
Of course feel free to reject PR if you don't like it